### PR TITLE
Change the AL output to "al" instead of "Al".

### DIFF
--- a/sounds/aw_ow_-k.md
+++ b/sounds/aw_ow_-k.md
@@ -33,7 +33,7 @@ AU
 
 * `SAU`: saw
 * `TAUBG`: talk \(`TABG`: tack\)
-* `AUL`: all \(`AL`: Al\)
+* `AUL`: all \(`AL`: al\)
 * `PAUL`: Paul
 
 #### `OU`: the "ow" sound.


### PR DESCRIPTION
Per the current dictionary for Plover it seems like "Al" should be stroked as "AL/AL" and "al" is "AL".