### PR TITLE
Change KWEUP output to "equip" instead of "quip".

### DIFF
--- a/sounds/f_q.md
+++ b/sounds/f_q.md
@@ -27,7 +27,7 @@ Q
 * `KWEUBG`: quick
 * `KWABG`: quack
 * `KWEUZ`: quiz
-* `KWEUP`: quip
+* `KWEUP`: equip
 * `KWAD`: quad
 * `KWEURBG`: quirk
 * `SKWARB`: squash


### PR DESCRIPTION
Per the current dictionary for Plover it seems like `KWEUP` should output `equip` whereas `KW*EUP` is the stroke for `quip`.